### PR TITLE
Set `byrow = TRUE`

### DIFF
--- a/R/plot.R
+++ b/R/plot.R
@@ -568,7 +568,7 @@ plot_posterior_distribution <- function(mcmc_output, data, pred, prey,
     ggtitle(paste(title, "\nfor the", colnames(data$o)[pred_index], "predator")) +
     ylab("Density") +
     scale_shape_manual(values = c(seq(1:10))) +
-    guides(colour = guide_legend(byrow = 1, ncol = 1), shape = guide_legend(byrow = 1, ncol = 1)) +
+    guides(colour = guide_legend(byrow = TRUE, ncol = 1), shape = guide_legend(byrow = TRUE, ncol = 1)) +
     xlim(0, 1) +
     theme_bw() +
     theme(axis.title.x = element_blank(),


### PR DESCRIPTION
Hi there,

We have been preparing a new release of ggplot2 and during a reverse dependency check, it became apparent that the prospective ggplot2 3.5.0 would break EcoDiet.

The breakage appears to be just in 1 line of the vignette, which should be fixed by this PR. I was unable to confirm that the vignette was able to render properly due to missing system requirements, so it might be diligent to double check this.

To test the code changes with the release candidate, you can install it with the code below:

```r
remotes::install_github("tidyverse/ggplot2", ref = remotes::github_pull("5592"))
```

The release of ggplot2 3.5.0 is scheduled for the 12th of February. The progress of the release can be tracked in https://github.com/tidyverse/ggplot2/issues/5588. We hope that this PR might help EcoDiet get out a fix if necessary.