### PR TITLE
Update for current version of ggplot

### DIFF
--- a/R/plot.R
+++ b/R/plot.R
@@ -563,19 +563,18 @@ plot_posterior_distribution <- function(mcmc_output, data, pred, prey,
   
   # Trick to scale the plot and not have a warning from the CRAN check:
   variable_to_plot <- NULL
-  ..scaled.. <- NULL
   Prey <- NULL
 
   # Plot these values to represent the approximated probability densities
   figure <- ggplot(df_to_plot) +
-    geom_density(aes(x = variable_to_plot, y = ..scaled.., fill = Prey),
+    geom_density(aes(x = variable_to_plot, y = after_stat(scaled), fill = Prey),
                  alpha = .3, adjust = 1/2, na.rm = TRUE) +
-    geom_density(aes(x = variable_to_plot, y = ..scaled.., color = Prey),
+    geom_density(aes(x = variable_to_plot, y = after_stat(scaled), color = Prey),
                  size = 1.25, adjust = 1/2, na.rm = TRUE) +
     ggtitle(paste(title, "\nfor the", colnames(data$o)[pred_index], "predator")) +
     ylab("Density") +
     scale_shape_manual(values = c(seq(1:10))) +
-    guides(colour = guide_legend(byrow = 1, ncol = 1), shape = guide_legend(byrow = 1, ncol = 1)) +
+    guides(colour = guide_legend(byrow = TRUE, ncol = 1), shape = guide_legend(byrow = TRUE, ncol = 1)) +
     xlim(0, 1) +
     theme_bw() +
     theme(axis.title.x = element_blank(),


### PR DESCRIPTION
`plot_posterior_distribution()` gives an error "The `legend.byrow` theme element must be a <logical> object." This must be due to an update to ggplot2 that has stricter check of the argument types. The fix is to change `byrow = 1` to `byrow = TRUE`.

While I was at it I also fixed the warning: "The dot-dot notation (`..scaled..`) was deprecated in ggplot2 3.4.0.".